### PR TITLE
Group Todos by Month and Update UI Layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,28 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # services:
-    #  redis:
-    #    image: redis
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: shailaja
+          POSTGRES_PASSWORD: shailu_123
+          POSTGRES_DB: shailus_db_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      PGHOST: localhost
+      PGUSER: shailaja
+      PGPASSWORD: shailu_123
+      DATABASE_URL: postgres://shailaja:shailu_123@localhost:5432/shailus_db_test
+
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config google-chrome-stable
@@ -75,11 +91,13 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Set up DB
+        run: |
+          bin/rails db:setup
+          bin/rails db:test:prepare
+
       - name: Run tests
-        env:
-          RAILS_ENV: test
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: bin/rails test test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "rails", "~> 8.0.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", ">= 2.1"
+gem "pg", "~> 1.5"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -309,14 +310,6 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (~> 1.3.1)
-    sqlite3 (2.7.0-aarch64-linux-gnu)
-    sqlite3 (2.7.0-aarch64-linux-musl)
-    sqlite3 (2.7.0-arm-linux-gnu)
-    sqlite3 (2.7.0-arm-linux-musl)
-    sqlite3 (2.7.0-arm64-darwin)
-    sqlite3 (2.7.0-x86_64-darwin)
-    sqlite3 (2.7.0-x86_64-linux-gnu)
-    sqlite3 (2.7.0-x86_64-linux-musl)
     sshkit (1.24.0)
       base64
       logger
@@ -378,6 +371,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  pg (~> 1.5)
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
@@ -386,7 +380,6 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
-  sqlite3 (>= 2.1)
   stimulus-rails
   thruster
   turbo-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -172,3 +172,12 @@ body, html {
   margin: 0;
   padding-left: 20px;
 }
+.month-header {
+  margin-top: 40px;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #3a8dde;
+  border-bottom: 2px solid #a5d8ff;
+  padding-bottom: 8px;
+}
+

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,7 +15,7 @@ body, html {
 
 .todo-container {
   width: 100%;
-  max-width: 500px;
+  max-width: 600px;
   padding: 40px;
   background: #ffffff;
   border-radius: 20px;
@@ -24,55 +24,11 @@ body, html {
 }
 
 .todo-container h1 {
-  font-size: 2rem;
-  color: #333;
-  margin-bottom: 30px;
-  font-weight: 600;
-}
-
-.todo-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.task {
-  background: #f0f4f8;
-  margin-bottom: 16px;
-  padding: 15px 20px;
-  border-radius: 12px;
-  font-size: 1.1rem;
-  display: flex;
-  align-items: center;
-  justify-content: start;
-  transition: background 0.3s ease;
-  color: #444;
-}
-
-.task .checkbox {
-  font-size: 1.3rem;
-  margin-right: 12px;
-}
-
-.completed {
-  background: #e3fcef;
-  color: #1b5e20;
-  font-weight: 500;
-}
-
-.pending {
-  background: #ffeef0;
-  color: #c62828;
-  font-weight: 500;
-}
-.todo-container h1 {
   font-size: 2.5rem;
   font-weight: 600;
-  color: #3a8dde; 
-  text-align: center;
+  color: #3a8dde;
   margin-bottom: 30px;
   position: relative;
-  font-family: 'Inter', sans-serif;
   letter-spacing: 0.5px;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
@@ -88,3 +44,131 @@ body, html {
   box-shadow: 0 2px 4px rgba(58, 141, 222, 0.3);
 }
 
+.form-group {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 25px;
+}
+
+.todo-input {
+  flex: 1;
+  padding: 12px 16px;
+  font-size: 1rem;
+  border: 2px solid #a5d8ff;
+  border-right: none;
+  border-radius: 8px 0 0 8px;
+  outline: none;
+}
+
+.add-button {
+  padding: 12px 20px;
+  background-color: #3a8dde;
+  color: white;
+  border: 2px solid #3a8dde;
+  border-radius: 0 8px 8px 0;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.add-button:hover {
+  background-color: #1c6fd4;
+}
+
+.todo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.task {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #f0f4f8;
+  margin-bottom: 16px;
+  padding: 15px 20px;
+  border-radius: 12px;
+  font-size: 1.1rem;
+  color: #444;
+  transition: background 0.3s ease;
+}
+
+.task.completed {
+  background: #e3fcef;
+  color: #1b5e20;
+  font-weight: 500;
+  text-decoration: line-through;
+}
+
+.task.pending {
+  background: #ffeef0;
+  color: #c62828;
+  font-weight: 500;
+}
+
+.checkbox-button {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  margin-right: 10px;
+  cursor: pointer;
+}
+
+.task-title {
+  flex-grow: 1;
+  text-align: left;
+  padding-left: 10px;
+}
+
+.delete-button {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  color: #c62828;
+  cursor: pointer;
+}
+.actions {
+  display: flex;
+  gap: 10px;
+}
+
+.action-button {
+  padding: 8px 14px;
+  font-size: 0.9rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.action-button.complete {
+  background-color: #34a853;
+  color: white;
+}
+
+.action-button.complete:hover {
+  background-color: #2c8b45;
+}
+
+.action-button.delete {
+  background-color: #ea4335;
+  color: white;
+}
+
+.action-button.delete:hover {
+  background-color: #c62828;
+}
+.error-messages {
+  background-color: #ffebee;
+  color: #c62828;
+  padding: 10px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 0.95rem;
+  text-align: left;
+}
+
+.error-messages ul {
+  margin: 0;
+  padding-left: 20px;
+}

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,6 +1,9 @@
 class TodosController < ApplicationController
   def index
-    @todos = Todo.all.order(created_at: :desc)
+    @todos_grouped_by_month = Todo
+      .order(created_at: :desc)
+      .group_by { |todo| todo.created_at.strftime("%B %Y") }
+
     @todo = Todo.new
   end
 
@@ -10,7 +13,7 @@ class TodosController < ApplicationController
     if @todo.save
       redirect_to root_path
     else
-      @todos = Todo.all.order(created_at: :desc) 
+      @todos_grouped_by_month = Todo.order(created_at: :desc).group_by { |todo| todo.created_at.strftime("%B %Y") }
       render :index, status: :unprocessable_entity
     end
   end

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,0 +1,35 @@
+class TodosController < ApplicationController
+  def index
+    @todos = Todo.all.order(created_at: :desc)
+    @todo = Todo.new
+  end
+
+  def create
+    @todo = Todo.new(todo_params)
+    @todo.completed = false
+    if @todo.save
+      redirect_to root_path
+    else
+      @todos = Todo.all.order(created_at: :desc) 
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @todo = Todo.find(params[:id])
+    @todo.update(completed: !@todo.completed)
+    redirect_to root_path
+  end
+
+  def destroy
+    @todo = Todo.find(params[:id])
+    @todo.destroy
+    redirect_to root_path
+  end
+
+  private
+
+  def todo_params
+    params.require(:todo).permit(:title)
+  end
+end

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -1,0 +1,2 @@
+module TodosHelper
+end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,0 +1,3 @@
+class Todo < ApplicationRecord
+  validates :title, presence: true, length: { minimum: 3, maximum: 100 }
+end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,3 +1,3 @@
 class Todo < ApplicationRecord
-  validates :title, presence: true, length: { minimum: 3, maximum: 100 }
+  validates :title, presence: true, uniqueness: true, length: { minimum: 3, maximum: 100 }
 end

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,0 +1,36 @@
+<div class="page-wrapper">
+  <div class="todo-container">
+    <h1>📋 My ToDo List</h1>
+
+    <%= form_with(model: @todo, url: todos_path, local: true) do |f| %>
+      <div class="form-group">
+        <%= f.text_field :title, placeholder: "Enter a new task", class: "todo-input" %>
+        <%= f.submit "Add", class: "add-button" %>
+      </div>
+
+      <% if @todo.errors.any? %>
+        <div class="error-messages">
+          <ul>
+            <% @todo.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    <% end %>
+
+    <ul class="todo-list">
+      <% @todos.each do |todo| %>
+        <li class="task <%= todo.completed ? 'completed' : 'pending' %>">
+          <span class="task-title"><%= todo.title %></span>
+          <div class="actions">
+            <% unless todo.completed %>
+              <%= button_to "Mark as Completed", todo_path(todo), method: :patch, class: "action-button complete" %>
+            <% end %>
+            <%= button_to "Delete", todo_path(todo), method: :delete, class: "action-button delete" %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -19,18 +19,21 @@
       <% end %>
     <% end %>
 
-    <ul class="todo-list">
-      <% @todos.each do |todo| %>
-        <li class="task <%= todo.completed ? 'completed' : 'pending' %>">
-          <span class="task-title"><%= todo.title %></span>
-          <div class="actions">
-            <% unless todo.completed %>
-              <%= button_to "Mark as Completed", todo_path(todo), method: :patch, class: "action-button complete" %>
-            <% end %>
-            <%= button_to "Delete", todo_path(todo), method: :delete, class: "action-button delete" %>
-          </div>
-        </li>
-      <% end %>
-    </ul>
+    <% @todos_grouped_by_month.each do |month, todos| %>
+      <h2 class="month-header">🗓 <%= month %></h2>
+      <ul class="todo-list">
+        <% todos.each do |todo| %>
+          <li class="task <%= todo.completed ? 'completed' : 'pending' %>">
+            <span class="task-title"><%= todo.title %></span>
+            <div class="actions">
+              <% unless todo.completed %>
+                <%= button_to "Mark as Completed", todo_path(todo), method: :patch, class: "action-button complete" %>
+              <% end %>
+              <%= button_to "Delete", todo_path(todo), method: :delete, class: "action-button delete" %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,41 +1,19 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  username: shailaja
+  password: shailu_123
+  host: localhost
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: shailus_db
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: storage/test.sqlite3
+  database: shailus_db_test
 
-
-# Store production database in the storage/ directory, which by default
-# is mounted as a persistent Docker volume in config/deploy.yml.
 production:
-  primary:
-    <<: *default
-    database: storage/production.sqlite3
-  cache:
-    <<: *default
-    database: storage/production_cache.sqlite3
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *default
-    database: storage/production_queue.sqlite3
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *default
-    database: storage/production_cable.sqlite3
-    migrations_paths: db/cable_migrate
+  <<: *default
+  database: shailus_db_production

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get "pages/home"
-  root "pages#home"
+  root "todos#index"
+  resources :todos, only: [:index, :create, :destroy, :update]
 end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root "todos#index"
-  resources :todos, only: [:index, :create, :destroy, :update]
+  resources :todos, only: [ :index, :create, :destroy, :update ]
 end

--- a/db/migrate/20250619115657_create_todos.rb
+++ b/db/migrate/20250619115657_create_todos.rb
@@ -1,0 +1,10 @@
+class CreateTodos < ActiveRecord::Migration[8.0]
+  def change
+    create_table :todos do |t|
+      t.string :title
+      t.boolean :completed
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,20 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_06_19_115657) do
+  create_table "todos", force: :cascade do |t|
+    t.string "title"
+    t.boolean "completed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_06_19_115657) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "todos", force: :cascade do |t|
     t.string "title"
     t.boolean "completed"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,2 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+Todo.create!(title: "Learn Ruby", completed: true)
+Todo.create!(title: "Practice Rails", completed: false)

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class PagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get home" do
-    get pages_home_url
-    assert_response :success
-  end
-end

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TodosControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class TodosControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should get index" do
+    get root_url
+    assert_response :success
+  end
 end

--- a/test/fixtures/todos.yml
+++ b/test/fixtures/todos.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  completed: false
+
+two:
+  title: MyString
+  completed: false

--- a/test/models/todo_test.rb
+++ b/test/models/todo_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TodoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 📌 What does this PR do?

- This PR introduces a feature that groups todos by the month they were created and updates the frontend layout accordingly.

- It includes the:

     - Implemented logic to group todos by month using their creation date (created_at). This improves organization and enhances the user experience by visually separating tasks month-wise.

    - Refactored the main todos view to iterate over @todos_grouped_by_month. Added monthly headers and improved visual hierarchy with semantic HTML.

    - Updated styles to support the new layout, including styles for the month headers, grouped lists, and consistent formatting for form and task items.

### ✅Already Done

- Connected the application to a PostgreSQL database.

- Basic CRUD operations for todos are already implemented.

### Thank you😊.

**Screenshots of the updated UI 👀:**
<img width="1166" alt="Screenshot 2025-06-19 at 10 27 10 PM" src="https://github.com/user-attachments/assets/657907b0-2f16-4d33-b293-13ff9b83ef18" />

